### PR TITLE
Remove incorrect use of the term "library"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # sapsanLCD
-library to friend arduino mega with Osram Programmable display PD44xx
+Sketch to friend arduino mega with Osram Programmable display PD44xx


### PR DESCRIPTION
This is a sketch, not a library, so it's incorrect to call it a "library".

This error also occurs in the repository description. That can not be fixed via a pull request but it's easily done by clicking the **Edit** button to the right of the description text shown at the top of the repository's home page:
https://github.com/theBaldSoprano/osramPD44xxToArduino
